### PR TITLE
pc - add GET by id to UCSBDiningCommonsMenuItem controller

### DIFF
--- a/.github/workflows/58-javadoc-pr.yml
+++ b/.github/workflows/58-javadoc-pr.yml
@@ -75,7 +75,7 @@ jobs:
          java-version-file: ./.java-version
   
     - name: Build javadoc
-      run: mvn -DskipTests javadoc:javadoc
+      run: mvn -DskipTests -Dmaven.javadoc.failOnError=false javadoc:javadoc 
  
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@v4

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,6 +1,8 @@
 package edu.ucsb.cs156.example.controllers;
 
+import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/ucsbdiningcommonsmenuitem")
 @RestController
 @Slf4j
-public class UCSBDiningCommonsMenuItemController {
+public class UCSBDiningCommonsMenuItemController extends ApiController {
     
     @Autowired
     UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
@@ -72,6 +74,24 @@ public class UCSBDiningCommonsMenuItemController {
 
         return savedItem;
     }
+
+     /**
+     * Get a single dining commons menu item by id
+     * 
+     * @param id the id of the dining commons menu item
+     * @return a UCSBDiningCommonsMenuItem
+     */
+    @Operation(summary= "Get a single UCSBDiningCommonsMenuItem")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBDiningCommonsMenuItem getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem item = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        return item;
+    }
+
 
 }
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,77 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * This is a REST controller for UCSBDiningCommonsMenuItemController
+ */
+
+@Tag(name = "UCSBDiningCommonsMenuItemController")
+@RequestMapping("/api/ucsbdiningcommonsmenuitem")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController {
+    
+    @Autowired
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    /**
+     * List all UCSB dining commons menu items
+     * 
+     * @return an iterable of UCSBDDiningCommonsMenuitem
+     */
+
+    @Operation(summary= "List all ucsb dining commons menu items")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItems() {
+        Iterable<UCSBDiningCommonsMenuItem> items = ucsbDiningCommonsMenuItemRepository.findAll();
+        return items;
+    }
+
+     /**
+     * Create a new dining commons menu item
+     * 
+     * @param diningCommonsCode  the dining commons code
+     * @param name          the name of the item
+     * @param localDateTime the station at which the item is served
+     * @return the saved item
+     */
+    @Operation(summary= "Create a new dining commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem (
+            @Parameter(name="diningCommonsCode") @RequestParam String diningCommonsCode,
+            @Parameter(name="name") @RequestParam String name,
+            @Parameter(name="station") @RequestParam String station)
+            throws JsonProcessingException {
+
+        UCSBDiningCommonsMenuItem item = new UCSBDiningCommonsMenuItem();
+
+        item.setDiningCommonsCode(diningCommonsCode);
+        item.setName(name);
+        item.setStation(station);
+
+        UCSBDiningCommonsMenuItem savedItem = ucsbDiningCommonsMenuItemRepository.save(item);
+
+        return savedItem;
+    }
+
+}
+

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a UCSBDiningCommonsMenuItem
+ * 
+ * A UCSBDiningCommonsMenuItem is a dining commons menu item at UCSB
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitems")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,6 +1,6 @@
 package edu.ucsb.cs156.example.repositories;
 
-import edu.ucsb.cs156.example.entities.UCSBDiningCommons;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Repository;
  * The UCSBDiningCommonsRepository is a repository for UCSBDiningCommons entities
  */
 @Repository
-public interface UCSBDiningCommonsRepository extends CrudRepository<UCSBDiningCommons, String> {
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {
  
 }

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
@@ -35,7 +35,7 @@
                   },
                   {
                     "column": {
-                      "name": "DININGCOMMONSCODE",
+                      "name": "DINING_COMMONS_CODE",
                       "type": "VARCHAR(255)"
                     }
                   },

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItems.json
@@ -1,0 +1,62 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBDiningCommonsMenuItems",
+          "author": "phtcon",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDININGCOMMONSMENUITEMS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBDININGCOMMONSMENUITEMS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DININGCOMMONSCODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "UCSBDININGCOMMONSMENUITEMS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -6,8 +6,12 @@ import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
 import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -32,7 +36,7 @@ import static org.mockito.Mockito.when;
 public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
 
         @MockBean
-        UCSBDiningCommonsMenuItemRepository UCSBDiningCommonsMenuItemRepository;
+        UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
 
         @MockBean
         UserRepository userRepository;
@@ -88,7 +92,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
                 ArrayList<UCSBDiningCommonsMenuItem> expectedDates = new ArrayList<>();
                 expectedDates.addAll(Arrays.asList(UCSBDiningCommonsMenuItem1, UCSBDiningCommonsMenuItem2));
 
-                when(UCSBDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedDates);
+                when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedDates);
 
                 // act
                 MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
@@ -96,7 +100,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
                 // assert
 
-                verify(UCSBDiningCommonsMenuItemRepository, times(1)).findAll();
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
                 String expectedJson = mapper.writeValueAsString(expectedDates);
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
@@ -113,7 +117,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
                                 .station("entrees")
                                 .build();
 
-                when(UCSBDiningCommonsMenuItemRepository.save(eq(UCSBDiningCommonsMenuItem1)))
+                when(ucsbDiningCommonsMenuItemRepository.save(eq(UCSBDiningCommonsMenuItem1)))
                                 .thenReturn(UCSBDiningCommonsMenuItem1);
 
                 // act
@@ -123,10 +127,64 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
-                verify(UCSBDiningCommonsMenuItemRepository, times(1)).save(UCSBDiningCommonsMenuItem1);
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(UCSBDiningCommonsMenuItem1);
                 String expectedJson = mapper.writeValueAsString(UCSBDiningCommonsMenuItem1);
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
+        }
+
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+           @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                UCSBDiningCommonsMenuItem UCSBDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("ortega")
+                                .name("Burger")
+                                .station("entrees")
+                                .build();
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(UCSBDiningCommonsMenuItem1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(UCSBDiningCommonsMenuItem1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
         }
 
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,132 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UCSBDiningCommonsMenuItemRepository UCSBDiningCommonsMenuItemRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/ucsbdiningcommonsmenuitem/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        // Authorization tests for /api/ucsbdiningcommonsmenuitem/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_UCSBDiningCommonsMenuItem() throws Exception {
+
+                UCSBDiningCommonsMenuItem UCSBDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("ortega")
+                                .name("Burger")
+                                .station("entrees")
+                                .build();
+
+
+                UCSBDiningCommonsMenuItem UCSBDiningCommonsMenuItem2 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("ortega")
+                                .name("Burger")
+                                .station("entrees")
+                                .build();
+
+                ArrayList<UCSBDiningCommonsMenuItem> expectedDates = new ArrayList<>();
+                expectedDates.addAll(Arrays.asList(UCSBDiningCommonsMenuItem1, UCSBDiningCommonsMenuItem2));
+
+                when(UCSBDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedDates);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(UCSBDiningCommonsMenuItemRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedDates);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_UCSBDiningCommonsMenuItem() throws Exception {
+                // arrange
+
+                UCSBDiningCommonsMenuItem UCSBDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("ortega")
+                                .name("Burger")
+                                .station("entrees")
+                                .build();
+
+                when(UCSBDiningCommonsMenuItemRepository.save(eq(UCSBDiningCommonsMenuItem1)))
+                                .thenReturn(UCSBDiningCommonsMenuItem1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/ucsbdiningcommonsmenuitem/post?name=Burger&station=entrees&diningCommonsCode=ortega")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(UCSBDiningCommonsMenuItemRepository, times(1)).save(UCSBDiningCommonsMenuItem1);
+                String expectedJson = mapper.writeValueAsString(UCSBDiningCommonsMenuItem1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+}


### PR DESCRIPTION
Merge AFTER #46 

In this PR, we add an API endpoint to get a UCSBDiningCommonsMenuItem by its id.


# To test

* Login to https://team01-dev-pconrad.dokku-00.cs.ucsb.edu
* Go to swagger
* Try the GET (/all) on UCSBDiningCommonsMenuItem.  If at least one record already exists in the database, you can use that id; otherwise do a POST to create one.
* Try the GET by id on an id that exists, and one that doesn't exist.


<img width="813" alt="image" src="https://github.com/user-attachments/assets/e68d62bd-508f-4f68-95e2-efc2f58311ea">
