### PR TITLE
pc - create database table for Commits

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/Commit.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Commit.java
@@ -1,0 +1,32 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+/**
+ * This is a JPA entity that represents a Github Commit.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "commits")
+public class Commit {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String message;
+  private String url;
+  private String authorLogin;
+  ZonedDateTime commitTime;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/CommitRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/CommitRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Commit;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The CommitRepository is a repository for Commit entities.
+ */
+
+@Repository
+public interface CommitRepository extends CrudRepository<Commit, Long> {
+  
+}

--- a/src/main/resources/db/migration/changes/Commits.json
+++ b/src/main/resources/db/migration/changes/Commits.json
@@ -1,0 +1,68 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "Commits-1",
+          "author": "pconrad",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "COMMITS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "COMMITS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "MESSAGE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "URL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "AUTHOR_LOGIN",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COMMIT_TIME",
+                      "type": "TIMESTAMP WITH TIME ZONE"
+                    }
+                  }
+                ],
+                "tableName": "COMMITS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #51 

In this PR, we add a database tables that represents a Github commit, with the following fields:

```
String message;
String url; 
String authorLogin; 
ZonedDateTime commitTime;
```

You can test this by running on localhost and looking for the Commits table on the h2-console

<img width="254" alt="image" src="https://github.com/user-attachments/assets/af5cca87-61e5-417d-8dd5-31db7b1e0ff6">


You can also test this by running on dokku and connecting to the postgres database, and running \dt:

```
pconrad@dokku-00:~$ dokku postgres:connect team01-dev-pconrad1-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_pconrad1_db=# \dt
                   List of relations
 Schema |            Name            | Type  |  Owner   
--------+----------------------------+-------+----------
 public | commits                    | table | postgres
 public | databasechangelog          | table | postgres
 public | databasechangeloglock      | table | postgres
 public | restaurants                | table | postgres
 public | ucsbdates                  | table | postgres
 public | ucsbdiningcommons          | table | postgres
 public | ucsbdiningcommonsmenuitems | table | postgres
 public | ucsborganization           | table | postgres
 public | users                      | table | postgres
(9 rows)

team01_dev_pconrad1_db=# 

```