### PR TITLE
Pc put for commit table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/CommitsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/CommitsController.java
@@ -34,21 +34,21 @@ import java.time.ZonedDateTime;
  * This is a REST controller for Commits
  */
 
- @Tag(name = "Commits")
- @RequestMapping("/api/commits")
- @RestController
- @Slf4j
+@Tag(name = "Commits")
+@RequestMapping("/api/commits")
+@RestController
+@Slf4j
 public class CommitsController extends ApiController {
-    
+
     @Autowired
     CommitRepository commitRepository;
 
-     /**
+    /**
      * List all Commits
      * 
      * @return an iterable of Commits
      */
-    @Operation(summary= "List all commits")
+    @Operation(summary = "List all commits")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all")
     public Iterable<Commit> allCommits() {
@@ -56,23 +56,23 @@ public class CommitsController extends ApiController {
         return commits;
     }
 
-     /**
+    /**
      * Create a new commit
      * 
-     * @param message  the commit message
-     * @param url the commit url 
+     * @param message     the commit message
+     * @param url         the commit url
      * @param authorLogin the github login id of the user that authored the commit
-     * @param commitTime the timestamp on the commit, with time zone information
+     * @param commitTime  the timestamp on the commit, with time zone information
      * @return the saved commit
      */
-    @Operation(summary= "Create a new commit")
+    @Operation(summary = "Create a new commit")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public Commit postCommit(
-            @Parameter(name="message") @RequestParam String message,
-            @Parameter(name="url") @RequestParam String url,
-            @Parameter(name="authorLogin") @RequestParam String authorLogin,
-            @Parameter(name="commitTime") @RequestParam("commitTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) ZonedDateTime commitTime)
+            @Parameter(name = "message") @RequestParam String message,
+            @Parameter(name = "url") @RequestParam String url,
+            @Parameter(name = "authorLogin") @RequestParam String authorLogin,
+            @Parameter(name = "commitTime") @RequestParam("commitTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) ZonedDateTime commitTime)
             throws JsonProcessingException {
 
         // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
@@ -89,6 +89,23 @@ public class CommitsController extends ApiController {
         Commit savedCommit = commitRepository.save(commit);
 
         return savedCommit;
+    }
+
+    /**
+     * Get a single commit by id
+     * 
+     * @param id the id of the commit
+     * @return a Commit
+     */
+    @Operation(summary = "Get a single commit")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Commit getById(
+            @Parameter(name = "id") @RequestParam Long id) {
+        Commit commit = commitRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Commit.class, id));
+
+        return commit;
     }
 
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/CommitsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/CommitsController.java
@@ -1,0 +1,94 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.Commit;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.CommitRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+/**
+ * This is a REST controller for Commits
+ */
+
+ @Tag(name = "Commits")
+ @RequestMapping("/api/commits")
+ @RestController
+ @Slf4j
+public class CommitsController extends ApiController {
+    
+    @Autowired
+    CommitRepository commitRepository;
+
+     /**
+     * List all Commits
+     * 
+     * @return an iterable of Commits
+     */
+    @Operation(summary= "List all commits")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<Commit> allCommits() {
+        Iterable<Commit> commits = commitRepository.findAll();
+        return commits;
+    }
+
+     /**
+     * Create a new commit
+     * 
+     * @param message  the commit message
+     * @param url the commit url 
+     * @param authorLogin the github login id of the user that authored the commit
+     * @param commitTime the timestamp on the commit, with time zone information
+     * @return the saved commit
+     */
+    @Operation(summary= "Create a new commit")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public Commit postCommit(
+            @Parameter(name="message") @RequestParam String message,
+            @Parameter(name="url") @RequestParam String url,
+            @Parameter(name="authorLogin") @RequestParam String authorLogin,
+            @Parameter(name="commitTime") @RequestParam("commitTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) ZonedDateTime commitTime)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("commitTime={}", commitTime);
+
+        Commit commit = new Commit();
+        commit.setMessage(message);
+        commit.setUrl(url);
+        commit.setAuthorLogin(authorLogin);
+        commit.setCommitTime(commitTime);
+
+        Commit savedCommit = commitRepository.save(commit);
+
+        return savedCommit;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/CommitsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/CommitsController.java
@@ -108,4 +108,31 @@ public class CommitsController extends ApiController {
         return commit;
     }
 
+     /**
+     * Update a single commit
+     * 
+     * @param id       id of the commit to update
+     * @param incoming the new commit
+     * @return the updated commit object
+     */
+    @Operation(summary= "Update a single commit")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public Commit updateCommit(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid Commit incoming) {
+
+        Commit commit = commitRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Commit.class, id));
+
+        commit.setAuthorLogin(incoming.getAuthorLogin());
+        commit.setCommitTime(incoming.getCommitTime());
+        commit.setMessage(incoming.getMessage());
+        commit.setUrl(incoming.getUrl());
+       
+        commitRepository.save(commit);
+
+        return commit;
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/Commit.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Commit.java
@@ -1,0 +1,32 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+/**
+ * This is a JPA entity that represents a Github Commit.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "commits")
+public class Commit {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String message;
+  private String url;
+  private String authorLogin;
+  ZonedDateTime commitTime;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/CommitRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/CommitRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Commit;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The CommitRepository is a repository for Commit entities.
+ */
+
+@Repository
+public interface CommitRepository extends CrudRepository<Commit, Long> {
+  
+}

--- a/src/main/resources/db/migration/changes/Commits.json
+++ b/src/main/resources/db/migration/changes/Commits.json
@@ -1,0 +1,68 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "Commits-1",
+          "author": "pconrad",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "COMMITS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "COMMITS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "MESSAGE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "URL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "AUTHOR_LOGIN",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COMMIT_TIME",
+                      "type": "TIMESTAMP WITH TIME ZONE"
+                    }
+                  }
+                ],
+                "tableName": "COMMITS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/CommitsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/CommitsControllerTests.java
@@ -1,0 +1,142 @@
+package edu.ucsb.cs156.example.controllers;
+
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Commit;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.CommitRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.ZonedDateTime;
+
+@WebMvcTest(controllers = CommitsController.class)
+@Import(TestConfig.class)
+public class CommitsControllerTests extends ControllerTestCase  {
+    
+    @MockBean
+    CommitRepository commitRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/commits/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/commits/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/commits/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/commits/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+            // arrange
+
+            ZonedDateTime zdt1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+
+            Commit commit1 = Commit.builder()
+                .url("https://github.com/ucsb-cs156-f24/STARTER-team02/commit/e107dcbce881afa1ea70ebc93c8dfb91cebb8630")
+                .message("Merge pull request #212 from ucsb-cs156-f24/pc-update-pom-xml\n" +  "pc - update version in pom.xml")
+                .authorLogin("pconrad")
+                .commitTime(zdt1)
+                .build();
+
+            ArrayList<Commit> expectedCommits = new ArrayList<>();
+            expectedCommits.add(commit1);
+
+            when(commitRepository.findAll()).thenReturn(expectedCommits);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/commits/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(commitRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedCommits);
+
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_committ() throws Exception {
+            // arrange
+
+            ZonedDateTime zdt1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+
+            Commit commit1 = Commit.builder()
+            .url("https://github.com/ucsb-cs156-f24/STARTER-team02/commit/e107dcbce881afa1ea70ebc93c8dfb91cebb8630")
+            .message("pc-updated")
+            .authorLogin("pconrad")
+            .commitTime(zdt1)
+            .build();
+         
+
+            when(commitRepository.save(eq(commit1))).thenReturn(commit1);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/commits/post?message=pc-updated&url=https://github.com/ucsb-cs156-f24/STARTER-team02/commit/e107dcbce881afa1ea70ebc93c8dfb91cebb8630&authorLogin=pconrad&commitTime=2022-01-03T00:00:00Z")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(commitRepository, times(1)).save(eq(commit1));
+            String expectedJson = mapper.writeValueAsString(commit1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+}


### PR DESCRIPTION
Closes: #54 

In this PR, we add the PUT operations to the Commits Controller so that we will be able to edit existing commits.

<img width="706" alt="image" src="https://github.com/user-attachments/assets/c4735f6d-bd78-470a-9e89-e1d6ba7bd6bd">
